### PR TITLE
Add atanh documentation, implementation, and tests

### DIFF
--- a/docs/built-in-functions/atanh.mdx
+++ b/docs/built-in-functions/atanh.mdx
@@ -14,18 +14,21 @@ tags:
 import CodeBlock from '@theme/CodeBlock';
 import TestCode from '!!raw-loader!../../scripts/built-in-functions/atanh.test.mjs';
 import ImplementCode from '!!raw-loader!../../scripts/built-in-functions/atanh.mts';
+import LatexPlot from '@site/src/components/LatexPlot';
 
 ## 説明
 
 `tanh`は与えられた値を双曲線正接に変換し、結果は-1から1の範囲に収まります。`atanh`はその逆関数で、`tanh(x)`が特定の値になるような`x`を返します。つまり`tanh(atanh(y)) = y`となり、入力`y`は`|y| < 1`である必要があります。境界である`±1`に近づくと値は発散し、グラフは垂直に伸びていくような形になります。
 
-双曲線関数は指数関数から定義され、`atanh`も例外ではありません。以下の式のとおり、自然対数を用いて表現できます。
+双曲線関数は指数関数から定義されるため、逆関数である`atanh`も自然対数を用いて表現できます。
 
+<LatexPlot xMin={-0.99} xMax={0.99} samples={600} plotFunction={(x) => Math.atanh(x)}>
 $$
 \operatorname{atanh}(x) = \frac{1}{2}\ln\left(\frac{1 + x}{1 - x}\right)
 $$
+</LatexPlot>
 
-実装ではJavaScriptの`Math.atanh`を利用することで、スカラー値だけでなくベクトル型の成分ごとに逆双曲線正接を計算できます。
+実装ではJavaScriptの`Math.atanh`を利用することで計算できます。
 
 ## JSでの実装例
 

--- a/docs/built-in-functions/atanh.mdx
+++ b/docs/built-in-functions/atanh.mdx
@@ -17,7 +17,15 @@ import ImplementCode from '!!raw-loader!../../scripts/built-in-functions/atanh.m
 
 ## 説明
 
-// TODO
+`tanh`は与えられた値を双曲線正接に変換し、結果は-1から1の範囲に収まります。`atanh`はその逆関数で、`tanh(x)`が特定の値になるような`x`を返します。つまり`tanh(atanh(y)) = y`となり、入力`y`は`|y| < 1`である必要があります。境界である`±1`に近づくと値は発散し、グラフは垂直に伸びていくような形になります。
+
+双曲線関数は指数関数から定義され、`atanh`も例外ではありません。以下の式のとおり、自然対数を用いて表現できます。
+
+$$
+\operatorname{atanh}(x) = \frac{1}{2}\ln\left(\frac{1 + x}{1 - x}\right)
+$$
+
+実装ではJavaScriptの`Math.atanh`を利用することで、スカラー値だけでなくベクトル型の成分ごとに逆双曲線正接を計算できます。
 
 ## JSでの実装例
 

--- a/scripts/built-in-functions/atanh.mts
+++ b/scripts/built-in-functions/atanh.mts
@@ -1,1 +1,27 @@
-// TODO
+import type {genFType} from '../../types/index.mts';
+import {vec2, vector2} from '../basic-types/vec2.mts';
+import {vec3, vector3} from '../basic-types/vec3.mts';
+import {vec4, vector4} from '../basic-types/vec4.mts';
+
+const hyperbolicArcTangent = (x: number) => {
+    return Math.atanh(x);
+}
+
+export function atanh(x: genFType): genFType {
+    if (typeof x === 'number') {
+        return hyperbolicArcTangent(x);
+    } else if (x instanceof vector2) {
+        return vec2(hyperbolicArcTangent(x.x), hyperbolicArcTangent(x.y));
+    } else if (x instanceof vector3) {
+        return vec3(hyperbolicArcTangent(x.x), hyperbolicArcTangent(x.y), hyperbolicArcTangent(x.z));
+    } else if (x instanceof vector4) {
+        return vec4(
+            hyperbolicArcTangent(x.x),
+            hyperbolicArcTangent(x.y),
+            hyperbolicArcTangent(x.z),
+            hyperbolicArcTangent(x.w)
+        );
+    }
+
+    throw new Error('atanh: no matching overloaded function found');
+}

--- a/scripts/built-in-functions/atanh.test.mjs
+++ b/scripts/built-in-functions/atanh.test.mjs
@@ -1,1 +1,13 @@
-// TODO
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {atanh} from './atanh.mts';
+
+test('atanh with simple number', () => {
+    assert.strictEqual(atanh(0), 0);
+    assert.strictEqual(atanh(0.5), 0.5493061443340548);
+    assert.strictEqual(atanh(-0.5), -0.5493061443340548);
+    assert.strictEqual(atanh(0.9), 1.4722194895832204);
+    assert.strictEqual(atanh(-0.9), -1.4722194895832204);
+});
+
+// vec2以下のテストは省略する。

--- a/src/components/LatexPlot.js
+++ b/src/components/LatexPlot.js
@@ -1,0 +1,186 @@
+import React from 'react';
+
+/**
+ * @typedef {Object} LatexPlotProps
+ * @property {(x:number)=>number} plotFunction プロットする関数
+ * @property {number} [width=480] SVG の幅（px）
+ * @property {number} [height=300] SVG の高さ（px）
+ * @property {number} [xMin=-1] X 軸の最小値
+ * @property {number} [xMax=1] X 軸の最大値
+ * @property {number} [yMin] Y 軸の最小値（未指定なら自動計算）
+ * @property {number} [yMax] Y 軸の最大値（未指定なら自動計算）
+ * @property {number} [samples=400] サンプル点の数
+ * @property {React.ReactNode} [children] KaTeX 表示されるキャプション
+ */
+
+/**
+ * 関数のグラフを描画し、下部に LaTeX をキャプション表示します。
+ * @param {LatexPlotProps} props
+ * @returns {JSX.Element}
+ */
+export default function LatexPlot({
+    plotFunction,
+    width = 480,
+    height = 300,
+    xMin = -1,
+    xMax = 1,
+    yMin,
+    yMax,
+    samples = 400,
+    children,
+}) {
+    const xValues = [];
+    const yValues = [];
+    const xStep = (xMax - xMin) / Math.max(1, samples - 1);
+
+    for (let i = 0; i < samples; i++) {
+        const x = xMin + i * xStep;
+        let y;
+
+        try {
+            y = plotFunction(x);
+        } catch {
+            y = NaN;
+        }
+        
+        if (!Number.isFinite(y)) {
+            y = NaN
+        }
+
+        xValues.push(x);
+        yValues.push(y);
+    }
+
+    let yMinComputed = yMin;
+    let yMaxComputed = yMax;
+    if (yMinComputed === undefined || yMaxComputed === undefined) {
+        const finite = yValues.filter((v) => Number.isFinite(v));
+
+        if (finite.length > 0) {
+            const min = Math.min(...finite);
+            const max = Math.max(...finite);
+            const pad = 0.1 * (max - min || 1);
+
+            yMinComputed = yMinComputed ?? min - pad;
+            yMaxComputed = yMaxComputed ?? max + pad;
+        } else {
+            yMinComputed = -1;
+            yMaxComputed = 1;
+        }
+    }
+
+    const chartPadding = 36;
+    const innerWidth = width - chartPadding * 2;
+    const innerHeight = height - chartPadding * 2;
+    const scaleX = (x) => chartPadding + ((x - xMin) / (xMax - xMin)) * innerWidth;
+    const scaleY = (y) => height - chartPadding - ((y - yMinComputed) / (yMaxComputed - yMinComputed)) * innerHeight;
+
+    let pathData = '';
+    let isDrawing = false;
+
+    for (let i = 0; i < xValues.length; i++) {
+        const x = xValues[i];
+        const y = yValues[i];
+
+        if (!Number.isFinite(y)) {
+            isDrawing = false;
+
+            continue;
+        }
+
+        const svgX = scaleX(x);
+        const svgY = scaleY(y);
+
+        if (!isDrawing) {
+            pathData += `M ${svgX} ${svgY}`;
+            isDrawing = true;
+        } else {
+            pathData += ` L ${svgX} ${svgY}`;
+        }
+    }
+
+    const yAxisSvgX = xMin < 0 && 0 <= xMax ? scaleX(0) : null;
+    const xAxisSvgY = yMinComputed < 0 && 0 <= yMaxComputed ? scaleY(0) : null;
+
+    function computeNiceStep(x) {
+        const pow = Math.pow(10, Math.floor(Math.log10(x)));
+        const norm = x / pow;
+
+        let f = 1;
+
+        if (norm > 5) {
+            f = 10;
+        } else if (norm > 2) {
+            f = 5;
+        } else if (norm > 1) {
+            f = 2;
+        }
+
+        return f * pow;
+    }
+
+    function generateTicks(min, max, count = 5) {
+        const span = max - min;
+
+        if (!Number.isFinite(span) || span <= 0) {
+            return [];
+        }
+
+        const step = computeNiceStep(span / count);
+        const start = Math.ceil(min / step) * step;
+        const arr = [];
+
+        for (let v = start; v <= max + 1e-12; v += step) {
+            arr.push(+v.toFixed(10));
+        }
+
+        return arr;
+    }
+
+    const xTickValues = generateTicks(xMin, xMax, 6);
+    const yTickValues = generateTicks(yMinComputed, yMaxComputed, 4);
+
+    return (
+        <figure style={{ textAlign: 'center', margin: '2rem 0' }}>
+            <svg width={width} height={height}>
+                <rect x="0" y="0" width={width} height={height} fill="#fff" stroke="#e5e7eb" />
+
+                {/* 罫線 */}
+                {xTickValues.map((tx) => (
+                    <line key={`vx-${tx}`} x1={scaleX(tx)} y1={chartPadding} x2={scaleX(tx)} y2={height - chartPadding} stroke="#f3f4f6" />
+                ))}
+                {yTickValues.map((ty) => (
+                    <line key={`hy-${ty}`} x1={chartPadding} y1={scaleY(ty)} x2={width - chartPadding} y2={scaleY(ty)} stroke="#f3f4f6" />
+                ))}
+
+                {/* 軸 */}
+                {xAxisSvgY !== null && (
+                    <line x1={chartPadding} y1={xAxisSvgY} x2={width - chartPadding} y2={xAxisSvgY} stroke="#9ca3af" />
+                )}
+                {yAxisSvgX !== null && (
+                    <line x1={yAxisSvgX} y1={chartPadding} x2={yAxisSvgX} y2={height - chartPadding} stroke="#9ca3af" />
+                )}
+
+                {/* 目盛り */}
+                {xTickValues.map((tx) => (
+                    <g key={`xt-${tx}`} transform={`translate(${scaleX(tx)}, ${height - chartPadding + 16})`}>
+                        <text textAnchor="middle" fontSize="10" fill="#6b7280">{tx}</text>
+                    </g>
+                ))}
+                {yTickValues.map((ty) => (
+                    <g key={`yt-${ty}`} transform={`translate(${chartPadding - 8}, ${scaleY(ty) + 3})`}>
+                        <text textAnchor="end" fontSize="10" fill="#6b7280">{ty}</text>
+                    </g>
+                ))}
+
+                {/* グラフ */}
+                <path d={pathData} fill="none" stroke="#2563eb" strokeWidth="2" />
+            </svg>
+
+            {/* 関数式 */}
+            <figcaption style={{ textAlign: 'center', marginTop: '0.5rem' }}>
+                {children}
+            </figcaption>
+        </figure>
+    );
+}


### PR DESCRIPTION
## Summary
- explain the behavior and domain of `atanh` in the documentation page
- implement the GLSL-style `atanh` helper that supports scalar and vector inputs
- add unit tests that cover representative scalar values for `atanh`

## Testing
- `npx --yes node@22 --experimental-strip-types --test ./scripts/**/*.test.mjs` *(fails: repository still contains tests that depend on the missing `ava` package)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e014b30832488a69a8e1204c0a2