### PR TITLE
Add sinh documentation, implementation, and tests

### DIFF
--- a/docs/built-in-functions/sinh.mdx
+++ b/docs/built-in-functions/sinh.mdx
@@ -1,7 +1,6 @@
 ---
 title: sinh
 description: sinh関数をテストで理解する
-sidebar_position: 3
 reference:
     - https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html#angle-and-trigonometry-functions
     - https://registry.khronos.org/OpenGL-Refpages/es3/html/sinh.xhtml

--- a/docs/built-in-functions/sinh.mdx
+++ b/docs/built-in-functions/sinh.mdx
@@ -16,10 +16,21 @@ tags:
 import CodeBlock from '@theme/CodeBlock';
 import TestCode from '!!raw-loader!../../scripts/built-in-functions/sinh.test.mjs';
 import ImplementCode from '!!raw-loader!../../scripts/built-in-functions/sinh.mts';
+import LatexPlot from '@site/src/components/LatexPlot';
 
 ## 説明
 
-// TODO
+`sinh`は`hyperbolic sine`の略で、双曲線関数の1つ。引数`x`に対する双曲線正弦を返し、GLSLでは`float`だけでなく`vec2`や`vec3`などのベクトルにも要素ごとに適用される。
+
+引数は角度ではなく任意の実数として扱われ、指数関数を使った定義は次の通り。
+
+<LatexPlot xMin={-3} xMax={3} samples={600} plotFunction={(x) => Math.sinh(x)}>
+    $$
+    y = \sinh(x) = \frac{e^x - e^{-x}}{2}
+    $$
+</LatexPlot>
+
+`sinh`は奇関数なので`sinh(-x) = -sinh(x)`が成り立ち、`sin`のような周期性はなく絶対値が大きくなるほど指数関数的に増減する。JavaScriptでは`Math.sinh`が用意されているため、それを呼び出せば簡単に再現できる。
 
 ## JSでの実装例
 

--- a/scripts/built-in-functions/sinh.mts
+++ b/scripts/built-in-functions/sinh.mts
@@ -4,7 +4,6 @@ import {vec3, vector3} from '../basic-types/vec3.mts';
 import {vec4, vector4} from '../basic-types/vec4.mts';
 
 const hyperbolicSine = (x: number) => {
-    // JavaScriptの`Math`オブジェクトに`sinh`があるのでそれを使えば良い。
     const result = Math.sinh(x);
 
     // `Math.sinh(-0)`は-0を返すので0にそろえておく。

--- a/scripts/built-in-functions/sinh.mts
+++ b/scripts/built-in-functions/sinh.mts
@@ -1,1 +1,29 @@
-// TODO
+import type {genFType} from '../../types/index.mts';
+import {vec2, vector2} from '../basic-types/vec2.mts';
+import {vec3, vector3} from '../basic-types/vec3.mts';
+import {vec4, vector4} from '../basic-types/vec4.mts';
+
+const hyperbolicSine = (x: number) => {
+    // JavaScriptの`Math`オブジェクトに`sinh`があるのでそれを使えば良い。
+    const result = Math.sinh(x);
+
+    // `Math.sinh(-0)`は-0を返すので0にそろえておく。
+    return result === 0 ? 0 : result;
+};
+
+export function sinh(x: genFType): genFType {
+    if (typeof x === 'number') {
+        return hyperbolicSine(x);
+    } else if (x instanceof vector2) {
+        return vec2(hyperbolicSine(x.x), hyperbolicSine(x.y));
+    } else if (x instanceof vector3) {
+        return vec3(hyperbolicSine(x.x), hyperbolicSine(x.y), hyperbolicSine(x.z));
+    } else if (x instanceof vector4) {
+        return vec4(
+            hyperbolicSine(x.x),
+            hyperbolicSine(x.y),
+            hyperbolicSine(x.z),
+            hyperbolicSine(x.w),
+        );
+    }
+}

--- a/scripts/built-in-functions/sinh.test.mjs
+++ b/scripts/built-in-functions/sinh.test.mjs
@@ -1,1 +1,14 @@
-// TODO
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {sinh} from './sinh.mts';
+
+test('sinh with simple number', () => {
+    assert.strictEqual(sinh(0), 0);
+    assert.ok(Object.is(sinh(-0), 0));
+    assert.strictEqual(sinh(-1), -1.1752011936438014);
+    assert.strictEqual(sinh(1), 1.1752011936438014);
+    assert.strictEqual(sinh(-10), -11013.232874703393);
+    assert.strictEqual(sinh(10), 11013.232874703393);
+});
+
+// vec2以下のテストは省略する。


### PR DESCRIPTION
## Summary
- describe the GLSL `sinh` function in the documentation and embed a plot of the hyperbolic sine curve
- implement the `sinh` helper so it works with scalars and vector types while normalizing the `-0` case
- add unit tests that exercise representative scalar inputs for `sinh`

## Testing
- `npm test` *(fails: current Node.js v20.19.4 does not support --experimental-strip-types)*

------
https://chatgpt.com/codex/tasks/task_e_68cc05a321048324a5960a8909de05f3